### PR TITLE
Add environment variable documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration for ChemicAlly
+SECRET_KEY=changeme
+DEBUG=False

--- a/README.md
+++ b/README.md
@@ -82,7 +82,16 @@ To run a Django project on your machine, follow these general steps. Note that s
 - **Static Files and Media:**
   - If your project involves static files or media uploads, configure your development server to serve these files. In a production environment, you would use a web server like Nginx or Apache to handle this.
 
-- **Environment Variables:**
-  - Set any necessary environment variables if your project relies on them.
+ - **Environment Variables:**
+   - See the **Environment Variables** section below for required keys.
 
 Keep in mind that these are general steps, and you might need to adjust them based on your specific Django project setup and requirements. Always refer to your project's documentation or README for any project-specific instructions.
+
+## Environment Variables
+
+ChemicAlly expects certain configuration values to be supplied via environment variables. These values can be stored in a `.env` file at the project root. The following keys are required:
+
+- `SECRET_KEY` &ndash; Django's secret key used for cryptographic signing.
+- `DEBUG` &ndash; set to `True` to enable debug mode, otherwise `False`.
+
+You can copy `.env.example` to `.env` and fill in your own values.


### PR DESCRIPTION
## Summary
- document required environment variables in README
- add `.env.example` file showing expected keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bd1e98e083238ae39486d3843448