### PR TITLE
Add GitHub Actions CI to run Django tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Django Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SECRET_KEY: "test"
+      DEBUG: "False"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run Tests
+      run: |
+        python chemically/manage.py test webapp


### PR DESCRIPTION
## Summary
- run Django tests automatically on pushes and pull requests using GitHub Actions

## Testing
- `python chemically/manage.py test webapp`

------
https://chatgpt.com/codex/tasks/task_e_6858b415d7f08323920d3e25c4e1859f