### PR TITLE
Update DEBUG handling and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Example environment configuration for ChemicAlly
 SECRET_KEY=changeme
-DEBUG=False
+DEBUG=False  # "True" or "False"
 # Space-separated list of allowed hosts
 ALLOWED_HOSTS=localhost 127.0.0.1

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Keep in mind that these are general steps, and you might need to adjust them bas
 ChemicAlly expects certain configuration values to be supplied via environment variables. These values can be stored in a `.env` file at the project root. The following keys are required:
 
 - `SECRET_KEY` &ndash; Django's secret key used for cryptographic signing.
-- `DEBUG` &ndash; set to `True` to enable debug mode, otherwise `False`.
+- `DEBUG` &ndash; set to `"True"` to enable debug mode, otherwise `"False"`. The value is parsed as a boolean.
+- `ALLOWED_HOSTS` &ndash; space-separated list of hosts the application can serve.
 
 You can copy `.env.example` to `.env` and fill in your own values.
 

--- a/chemically/chemically/settings.py
+++ b/chemically/chemically/settings.py
@@ -27,7 +27,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", "False")
+# Cast DEBUG to boolean by comparing string value
+DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split()
 


### PR DESCRIPTION
## Summary
- convert DEBUG environment variable to boolean
- clarify DEBUG setting in `.env.example`
- document ALLOWED_HOSTS in README

## Testing
- `python chemically/manage.py test webapp`

------
https://chatgpt.com/codex/tasks/task_e_6858c2ded8e88323a80e9d5ca6ddd7bc