### PR TITLE
Fix import path and clean tests

### DIFF
--- a/chemically/webapp/tests.py
+++ b/chemically/webapp/tests.py
@@ -107,10 +107,6 @@ class FormTests(SimpleTestCase):
 class ViewTests(TestCase):
     def setUp(self):
         self.client = Client()
-        import sys
-        from webapp import utils as utils_pkg
-        sys.modules.setdefault("utils", utils_pkg)
-        sys.modules.setdefault("utils.units", utils_pkg.units)
 
     def test_molecular_weight_view_get(self):
         response = self.client.get(reverse("molecular_weight"))

--- a/chemically/webapp/views.py
+++ b/chemically/webapp/views.py
@@ -243,8 +243,7 @@ class CalculateDilutionView(BaseCalculateView):
                     )
 
             # Use Pint for units
-            from utils.units import \
-                Q_  # or wherever you define your UnitRegistry
+            from .utils.units import Q_  # use the package-local units helper
 
             unit_map = {"c1": c1_unit, "v1": v1_unit, "c2": c2_unit, "v2": v2_unit}
             quantity_map = {}


### PR DESCRIPTION
## Summary
- update DilutionCalculator view to use local units helper
- drop sys.modules test aliases

## Testing
- `python chemically/manage.py test webapp`

------
https://chatgpt.com/codex/tasks/task_e_685988b35aa483239fa94f0189c79597