### PR TITLE
Add context processor for previous substances

### DIFF
--- a/chemically/chemically/context_processors.py
+++ b/chemically/chemically/context_processors.py
@@ -1,6 +1,8 @@
 from typing import Dict, List
 from django.http import HttpRequest
 
+__all__ = ["previous_substances"]
+
 
 def previous_substances(request: HttpRequest) -> Dict[str, List[str]]:
     """Return previously viewed substances stored in the session.

--- a/chemically/chemically/context_processors.py
+++ b/chemically/chemically/context_processors.py
@@ -1,0 +1,21 @@
+from typing import Dict, List
+from django.http import HttpRequest
+
+
+def previous_substances(request: HttpRequest) -> Dict[str, List[str]]:
+    """Return previously viewed substances stored in the session.
+
+    Parameters
+    ----------
+    request : HttpRequest
+        The current HTTP request object.
+
+    Returns
+    -------
+    dict
+        Dictionary with key ``'previous_substances'`` mapping to a list of
+        substance strings stored in the session (defaults to an empty list).
+    """
+    return {
+        "previous_substances": request.session.get("previous_substances", [])
+    }

--- a/chemically/chemically/settings.py
+++ b/chemically/chemically/settings.py
@@ -68,6 +68,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'chemically.context_processors.previous_substances',
             ],
         },
     },

--- a/chemically/webapp/tests.py
+++ b/chemically/webapp/tests.py
@@ -137,3 +137,19 @@ class ViewTests(TestCase):
         response = self.client.post(reverse("dilution"), data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result"]["property"], "Initial Volume")
+
+class ContextProcessorTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        session = self.client.session
+        session['previous_substances'] = ['H2O']
+        session.save()
+
+    def test_context_available(self):
+        response = self.client.get(reverse('molecular_weight'))
+        self.assertEqual(response.context['previous_substances'], ['H2O'])
+
+    def test_session_updated_on_calculation(self):
+        self.client.post(reverse('molecular_weight'), {'formula': 'CO2'})
+        session = self.client.session
+        self.assertIn('CO2', session['previous_substances'])

--- a/chemically/webapp/utils/__init__.py
+++ b/chemically/webapp/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility helpers for the webapp package."""
+
+from typing import Iterable
+from django.http import HttpRequest
+
+
+def add_previous_substances(request: HttpRequest, substances: Iterable[str]) -> None:
+    """Persist a list of substance formulas to the session."""
+    prev = request.session.get("previous_substances", [])
+    for substance in substances:
+        if substance and substance not in prev:
+            prev.append(substance)
+    request.session["previous_substances"] = prev

--- a/chemically/webapp/views.py
+++ b/chemically/webapp/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import render, redirect
 from .calculations.base import (DilutionCalculator, MolecularWeightCalculator,
                                 ReactionBalancer)
 from .forms import ChemicalReactionForm, MolecularFormulaForm, SolutionForm
+from .utils import add_previous_substances
 import pint
 
 
@@ -135,6 +136,8 @@ class CalculateMolecularWeightView(BaseCalculateView):
             if molecular_weight is not None:
                 # Add the molecule:molecular_weight pair to the result dictionary
                 result[molecule] = molecular_weight
+        if result:
+            add_previous_substances(self.request, result.keys())
 
         return result
 
@@ -184,6 +187,7 @@ class BalanceChemicalReaction(BaseCalculateView):
             result = ReactionBalancer.to_latex(
                 reactancts_balanced, products_balanced, reversible
             )
+            add_previous_substances(self.request, reactancts + products)
             return result
         except Exception as e:
             messages.error(self.request, f"Error: {str(e)}")
@@ -317,6 +321,9 @@ class CalculateDilutionView(BaseCalculateView):
             # Include mass of solute if available
             if "mass_g" in result and result["mass_g"] is not None:
                 result_dict["solute_mass_g"] = float(result["mass_g"])
+
+            if solute_formula:
+                add_previous_substances(self.request, [solute_formula])
 
             return result_dict
 


### PR DESCRIPTION
## Summary
- introduce `previous_substances` context processor
- wire the context processor into Django templates

## Testing
- `python chemically/manage.py test webapp`

------
https://chatgpt.com/codex/tasks/task_e_685991b9a1988323a3758885cfc7a248