### PR TITLE
Fix dark mode toggle

### DIFF
--- a/chemically/webapp/static/js/dark_mode_enabler.js
+++ b/chemically/webapp/static/js/dark_mode_enabler.js
@@ -1,13 +1,15 @@
 document.addEventListener('DOMContentLoaded', function () {
-        const currentTheme = localStorage.getItem('theme') || 'light';
+        let currentTheme = localStorage.getItem('theme') || 'light';
 
         // Apply the current theme on page load
         applyTheme(currentTheme);
 
         // Toggle theme on click
+        // When the user clicks the theme text, toggle between light and dark
         document.getElementById('bd-theme-text').addEventListener('click', function () {
             const newTheme = currentTheme === 'light' ? 'dark' : 'light';
             applyTheme(newTheme);
+            currentTheme = newTheme;
             localStorage.setItem('theme', newTheme);
         });
 


### PR DESCRIPTION
## Summary
- update `currentTheme` to be mutable
- refresh stored theme after each click
- document dark mode toggle logic

## Testing
- `python chemically/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686341f356088323a9bbb52f9a744e0c