### PR TITLE
Fix Python version in GitHub workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use supported Python version

## Testing
- `python chemically/manage.py test webapp`

------
https://chatgpt.com/codex/tasks/task_e_686346ff95e0832387d6f006cf85087a