### PR TITLE
Add dynamic secret key setup in CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -25,6 +25,21 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Set up environment file
+      run: |
+        SECRET_KEY=$(python - <<'EOF'
+        from django.core.management.utils import get_random_secret_key
+        print(get_random_secret_key())
+        EOF
+        )
+        cat <<EOF > .env
+        SECRET_KEY=$SECRET_KEY
+        DEBUG=False
+        ALLOWED_HOSTS=localhost 127.0.0.1
+        EOF
+        set -a
+        source .env
+        set +a
     - name: Run Tests
       run: |
         cd chemically


### PR DESCRIPTION
## Summary
- create .env in workflow using Django's `get_random_secret_key`
- source generated environment so tests run with correct settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python chemically/manage.py test webapp`
- `pytest -q` *(no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_68634a3761ec8323a0d2e4e1bd63dfe8