### PR TITLE
Implement reaction input parsing

### DIFF
--- a/apps/webapp/utils/__init__.py
+++ b/apps/webapp/utils/__init__.py
@@ -11,3 +11,5 @@ def add_previous_substances(request: HttpRequest, substances: Iterable[str]) -> 
         if substance and substance not in prev:
             prev.append(substance)
     request.session["previous_substances"] = prev
+
+from .formula import smiles_to_formula

--- a/apps/webapp/utils/formula.py
+++ b/apps/webapp/utils/formula.py
@@ -1,0 +1,29 @@
+from collections import Counter
+
+
+def smiles_to_formula(smiles: str) -> str:
+    """Convert a SMILES string to a chemical formula."""
+    import pysmiles
+    import networkx as nx
+
+    mol = pysmiles.read_smiles(smiles, explicit_hydrogen=True)
+    counts = Counter(nx.get_node_attributes(mol, "element").values())
+    charge_total = sum(nx.get_node_attributes(mol, "charge").values())
+
+    parts = []
+    if "C" in counts:
+        c = counts.pop("C")
+        parts.append(f"C{c if c > 1 else ''}")
+    if "H" in counts:
+        h = counts.pop("H")
+        parts.append(f"H{h if h > 1 else ''}")
+    for el in sorted(counts):
+        num = counts[el]
+        parts.append(f"{el}{num if num > 1 else ''}")
+
+    formula = "".join(parts)
+    if charge_total > 0:
+        formula += f"{charge_total if charge_total > 1 else ''}+"
+    elif charge_total < 0:
+        formula += f"{abs(charge_total) if charge_total < -1 else ''}-"
+    return formula

--- a/apps/webapp/views.py
+++ b/apps/webapp/views.py
@@ -133,8 +133,8 @@ class CalculateMolecularWeightView(BaseCalculateView):
             weight.
         """
 
-        # Obtain the molecular formulas from the form and parse them into a list
-        molecules = [x.strip() for x in form.cleaned_data["formula"].split()]
+        # Obtain the list of molecular formulas from the form
+        molecules = form.cleaned_data["formula"]
         result = {}
         calculator = MolecularWeightCalculator()
         # Loop over the molecules list
@@ -187,8 +187,8 @@ class BalanceChemicalReaction(BaseCalculateView):
         try:
             reaction = form.cleaned_data
             reversible = reaction["reversible"]
-            reactants = [x.strip() for x in reaction["reactant"].split()]
-            products = [x.strip() for x in reaction["product"].split()]
+            reactants = reaction["reactant"]
+            products = reaction["product"]
             reactants_dict = {reactant for reactant in reactants}
             products_dict = {product for product in products}
             calculator = ReactionBalancer()
@@ -229,7 +229,8 @@ class CalculateDilutionView(BaseCalculateView):
 
         try:
             molecular_weight = cd.get("molecular_weight")
-            solute_formula = cd.get("solute")
+            solute_list = cd.get("solute")
+            solute_formula = solute_list[0] if solute_list else None
 
             from .utils.units import Q_
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,3 +3,5 @@ Django==5.2.3
 Pint==0.24.4
 pyparsing==3.2.3
 python-dotenv==1.1.0
+pysmiles==2.0.0
+networkx==3.5


### PR DESCRIPTION
## Summary
- extend `FormulaListField` to convert SMILES to formulas using pysmiles
- mention SMILES input in form help texts
- accept SMILES in solution form and reaction form
- add pysmiles and networkx dependencies
- test SMILES support for fields and forms
- handle charged molecules and add tests
- separate SMILES helper into utils

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686402fc7dfc832398ea1fef2592e3dc