### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -86,7 +86,7 @@ jobs:
         run: safety check --json --output safety-results.json || true
 
       - name: Upload scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: security-scan-results
           path: |
@@ -103,10 +103,10 @@ jobs:
     needs: [lint-and-test, security-scan]
     if: github.event_name == 'push' && github.ref == 'refs/heads/eb'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -145,7 +145,7 @@ jobs:
             -x ".platform/hooks/*"
 
       - name: Upload deploy package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: eb-deploy-package
           path: deploy.zip
@@ -161,15 +161,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/eb'
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download deploy package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: eb-deploy-package
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

Updates all GitHub Actions to their latest versions that support Node.js 24, eliminating deprecation warnings.

### Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v5` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/upload-artifact` | `v4` | `v5` |
| `actions/download-artifact` | `v4` | `v5` |
| `aws-actions/configure-aws-credentials` | `v4` | `v5` |

### Context

GitHub runners are migrating from Node.js 20 to Node.js 24:
- **June 2, 2026**: Node.js 24 becomes the default
- **September 16, 2026**: Node.js 20 removed from runners

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/