### PR TITLE
add branch guard rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,7 @@ tests/
 - Session stores substance history and calculator form state
 - Templates live in `templates/webapp/` and `templates/hplc_simulator/` (project-level `TEMPLATES.DIRS`)
 - HPLC simulator has a `SCIENTIFIC_LOGIC.md` documenting physical invariants — any changes to the simulation engine must respect these constraints
+
+## Agent Conduct
+
+- **Branch guard**: Before committing to any pre-existing branch (`main`, `eb`, or any branch that already exists before the current session), ask the user to confirm the target branch. Use worktrees (`createworktree`) for new feature branches.


### PR DESCRIPTION
Adds an **Agent Conduct** section to AGENTS.md with a branch guard rule that prevents the AI from committing to pre-existing branches (main, eb, etc.) without user confirmation. New features should use worktrees via `createworktree`.