### PR TITLE
split lint and test into independent CI jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,39 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────
-  # Stage 1: Lint & Test
+  # Stage 1a: Lint (independent)
   # ─────────────────────────────────────────────
-  lint-and-test:
-    name: Lint & Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements/*.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/development.txt
+
+      - name: Lint (Flake8)
+        run: flake8 .
+
+  # ─────────────────────────────────────────────
+  # Stage 1b: Test (independent of lint)
+  # ─────────────────────────────────────────────
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
@@ -43,9 +67,6 @@ jobs:
       - name: Set up environment
         run: cp .env.example .env
 
-      - name: Lint (Flake8)
-        run: flake8 .
-
       - name: Django deploy checks
         run: python manage.py check --deploy
 
@@ -58,7 +79,6 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
-    needs: lint-and-test
     steps:
       - uses: actions/checkout@v5
 
@@ -94,7 +114,7 @@ jobs:
   build:
     name: Build Deploy Package
     runs-on: ubuntu-latest
-    needs: [lint-and-test, security-scan]
+    needs: [lint, test, security-scan]
     if: github.event_name == 'push' && github.ref == 'refs/heads/eb'
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Separates the monolithic `lint-and-test` job into three independent jobs (`lint`, `test`, `security-scan`) that run in parallel. This way a lint failure no longer blocks tests from running — you see both results in the same CI run. `build`/`deploy` still gate on all three passing.