### PR TITLE
Fix deployment pipeline

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -268,7 +268,6 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref Certificate
           SslSupportMethod: sni-only
-        DefaultRootObject: ""
 
   # ─────────────────────────────────────────────
   # Route 53 A record (root domain)


### PR DESCRIPTION
Remove invalid `DefaultRootObject: ""` from CloudFront distribution.\n\nPrevious fixes already on main:\n- IMAGE_TAG uses run_number\n- SAM CLI pinned to 1.*\n- Safety CLI flag fixed\n- Docker no-cache\n- SAM --image-repository flag