### PR TITLE
Remove AWS::Lambda::ResourcePolicy (not available in us-east-2)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -157,29 +157,6 @@ Resources:
           - Authorization
         MaxAge: 86400
 
-  # ─────────────────────────────────────────────
-  # Resource policy to restrict Function URL to CloudFront only
-  # ─────────────────────────────────────────────
-  FunctionUrlResourcePolicy:
-    Type: AWS::Lambda::ResourcePolicy
-    Properties:
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal: "*"
-            Action: lambda:InvokeFunctionUrl
-            Condition:
-              StringEquals:
-                AWS:SourceArn: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}"
-          - Effect: Allow
-            Principal: "*"
-            Action: lambda:InvokeFunctionUrl
-            Condition:
-              IpAddress:
-                "AWS:SourceIp": "0.0.0.0/0"
-      Resource: !Ref DjangoFunction
-
   FunctionUrlPermission:
     Type: AWS::Lambda::Permission
     Properties:


### PR DESCRIPTION
Removes FunctionUrlResourcePolicy resource — AWS::Lambda::ResourcePolicy is not available in us-east-2. FunctionUrlPermission already grants invoke access, and CloudFront is the only public endpoint.